### PR TITLE
Fix a typo in the GetPlayerWeaponData native

### DIFF
--- a/omp_player.inc
+++ b/omp_player.inc
@@ -2208,7 +2208,7 @@ native GetPlayerAmmo(playerid);
  * slot specified is invalid (valid is <b><c>0-12</c></b>).
  * </returns>
  */
-native GetPlayerWeaponData(playerid, WEAPON_SLOT:slot, &WEAPON:weapons, &ammo);
+native GetPlayerWeaponData(playerid, WEAPON_SLOT:slot, &WEAPON:weapon, &ammo);
 
 /**
  * <library>omp_player</library>


### PR DESCRIPTION
Native `GetPlayerWeaponData` is passing a single weapon by reference; it should be passed as a singular.

It's been confirmed by Amir to be a typo here: https://discord.com/channels/231799104731217931/966398440051445790/1198371812061483198