### PR TITLE
Fix inline documentation for VehicleCanHaveComponent

### DIFF
--- a/omp_vehicle.inc
+++ b/omp_vehicle.inc
@@ -891,7 +891,7 @@ native bool:RemoveVehicleComponent(vehicleid, component);
 /**
  * <library>omp_vehicle</library>
  * <summary>Is this component legal on this vehicle model?</summary>
- * <param name="vehicleid">ID of the vehicle model.</param>
+ * <param name="modelid">ID of the vehicle model.</param>
  * <param name="component">ID of the <a href="https://www.open.mp/docs/scripting/resources/carcomponentid">component</a>
  * to check.</param>
  * <seealso name="AddVehicleComponent" />

--- a/omp_vehicle.inc
+++ b/omp_vehicle.inc
@@ -890,8 +890,8 @@ native bool:RemoveVehicleComponent(vehicleid, component);
 
 /**
  * <library>omp_vehicle</library>
- * <summary>Is this component legal on this vehicle?</summary>
- * <param name="vehicleid">ID of the vehicle.</param>
+ * <summary>Is this component legal on this vehicle model?</summary>
+ * <param name="vehicleid">ID of the vehicle model.</param>
  * <param name="component">ID of the <a href="https://www.open.mp/docs/scripting/resources/carcomponentid">component</a>
  * to check.</param>
  * <seealso name="AddVehicleComponent" />
@@ -900,7 +900,7 @@ native bool:RemoveVehicleComponent(vehicleid, component);
  * <seealso name="OnVehicleMod" />
  * <seealso name="OnEnterExitModShop" />
  */
-native bool:VehicleCanHaveComponent(vehicleid, componentid);
+native bool:VehicleCanHaveComponent(modelid, componentid);
 
 /**
  * <library>omp_vehicle</library>


### PR DESCRIPTION
Idk who wrote vehicleid there but it's supposed to be model

https://github.com/openmultiplayer/open.mp/blob/v1.5.8.3079/Server/Components/Pawn/Scripting/Vehicle/Natives.cpp#L285-L288