### PR TITLE
A bunch of optional parameters, a couple of missed tags

### DIFF
--- a/omp_npc.inc
+++ b/omp_npc.inc
@@ -560,7 +560,7 @@ native NPC_GetKeys(npcid, &upAnddown, &leftandRight, &keys);
 /**
  * <library>omp_npc</library>
  */
-native bool:NPC_MeleeAttack(npcid, time, bool:secondaryAttack = false);
+native bool:NPC_MeleeAttack(npcid, time = -1, bool:secondaryAttack = false);
 
 /**
  * <library>omp_npc</library>
@@ -642,7 +642,7 @@ native NPC_SetWeaponState(npcid, WEAPONSTATE:weaponState);
  * <seealso name="NPC_AimAt" />
  * <seealso name="NPC_SetWeapon" />
  */
-native NPC_Shoot(npcid, WEAPON:weaponid, hitId, hitType, Float:endPointX, Float:endPointY, Float:endPointZ, Float:offsetX, Float:offsetY, Float:offsetZ, bool:isHit, NPC_ENTITY_CHECK:checkInBetweenFlags = NPC_ENTITY_CHECK_ALL);
+native NPC_Shoot(npcid, WEAPON:weaponid, hitId, hitType, Float:endPointX, Float:endPointY, Float:endPointZ, Float:offsetX = 0.0, Float:offsetY = 0.0, Float:offsetZ = 0.0, bool:isHit = true, NPC_ENTITY_CHECK:checkInBetweenFlags = NPC_ENTITY_CHECK_ALL);
 
 /**
  * <library>omp_npc</library>
@@ -652,12 +652,12 @@ native bool:NPC_IsShooting(npcid);
 /**
  * <library>omp_npc</library>
  */
-native NPC_AimAt(npcid, Float:pointX, Float:pointY, Float:pointZ, bool:shoot, shootDelay, bool:updateAngle, Float:offsetFromX, Float:offsetFromY, Float:offsetFromZ, NPC_ENTITY_CHECK:checkInBetweenFlags = NPC_ENTITY_CHECK_ALL);
+native NPC_AimAt(npcid, Float:pointX, Float:pointY, Float:pointZ, bool:shoot = false, shootDelay = -1, bool:updateAngle = true, Float:offsetFromX = 0.0, Float:offsetFromY = 0.0, Float:offsetFromZ = 0.0, NPC_ENTITY_CHECK:checkInBetweenFlags = NPC_ENTITY_CHECK_ALL);
 
 /**
  * <library>omp_npc</library>
  */
-native NPC_AimAtPlayer(npcid, playerid, bool:shoot, shootDelay, bool:updateAngle, Float:offsetX, Float:offsetY, Float:offsetZ, Float:offsetFromX, Float:offsetFromY, Float:offsetFromZ, NPC_ENTITY_CHECK:checkInBetweenFlags = NPC_ENTITY_CHECK_ALL);
+native NPC_AimAtPlayer(npcid, playerid, bool:shoot = false, shootDelay = -1, bool:updateAngle = true, Float:offsetX = 0.0, Float:offsetY = 0.0, Float:offsetZ = 0.0, Float:offsetFromX = 0.0, Float:offsetFromY = 0.0, Float:offsetFromZ = 0.0, NPC_ENTITY_CHECK:checkInBetweenFlags = NPC_ENTITY_CHECK_ALL);
 
 /**
  * <library>omp_npc</library>

--- a/omp_npc.inc
+++ b/omp_npc.inc
@@ -491,7 +491,7 @@ native Float:NPC_GetArmour(npcid);
 /**
  * <library>omp_npc</library>
  */
-native NPC_SetInvulnerable(npcid, bool:toggle);
+native NPC_SetInvulnerable(npcid, bool:toggle = true);
 
 /**
  * <library>omp_npc</library>
@@ -525,7 +525,7 @@ native NPC_SetWeapon(npcid, WEAPON:weaponid);
 /**
  * <library>omp_npc</library>
  */
-native NPC_GetWeapon(npcid);
+native WEAPON:NPC_GetWeapon(npcid);
 
 /**
  * <library>omp_npc</library>
@@ -580,12 +580,12 @@ native NPC_SetFightingStyle(npcid, FIGHT_STYLE:style);
 /**
  * <library>omp_npc</library>
  */
-native NPC_GetFightingStyle(npcid);
+native FIGHT_STYLE:NPC_GetFightingStyle(npcid);
 
 /**
  * <library>omp_npc</library>
  */
-native bool:NPC_EnableReloading(npcid, bool:enable);
+native bool:NPC_EnableReloading(npcid, bool:enable = true);
 
 /**
  * <library>omp_npc</library>
@@ -600,7 +600,7 @@ native bool:NPC_IsReloading(npcid);
 /**
  * <library>omp_npc</library>
  */
-native bool:NPC_EnableInfiniteAmmo(npcid, bool:enable);
+native bool:NPC_EnableInfiniteAmmo(npcid, bool:enable = true);
 
 /**
  * <library>omp_npc</library>
@@ -610,7 +610,7 @@ native bool:NPC_IsInfiniteAmmoEnabled(npcid);
 /**
  * <library>omp_npc</library>
  */
-native NPC_GetWeaponState(npcid);
+native WEAPONSTATE:NPC_GetWeaponState(npcid);
 
 /**
  * <library>omp_npc</library>
@@ -862,7 +862,7 @@ native NPC_GetVehicleHydraThrusters(npcid);
 /**
  * <library>omp_npc</library>
  */
-native NPC_SetVehicleGearState(npcid, gearState);
+native NPC_SetVehicleGearState(npcid, LANDING_GEAR_STATE:gearState);
 
 /**
  * <library>omp_npc</library>
@@ -931,12 +931,12 @@ native
 /**
  * <library>omp_npc</library>
  */
-native bool:NPC_StartPlayback(npcid, const recordName[], bool:autoUnload, Float:startX, Float:startY, Float:startZ, Float:rotX, Float:rotY, Float:rotZ);
+native bool:NPC_StartPlayback(npcid, const recordName[], bool:autoUnload = false, Float:startX = 0.0, Float:startY = 0.0, Float:startZ = 0.0, Float:rotX = 0.0, Float:rotY = 0.0, Float:rotZ = 0.0);
 
 /**
  * <library>omp_npc</library>
  */
-native bool:NPC_StartPlaybackEx(npcid, recordId, bool:autoUnload, Float:startX, Float:startY, Float:startZ, Float:rotX, Float:rotY, Float:rotZ);
+native bool:NPC_StartPlaybackEx(npcid, recordId, bool:autoUnload = false, Float:startX = 0.0, Float:startY = 0.0, Float:startZ = 0.0, Float:rotX = 0.0, Float:rotY = 0.0, Float:rotZ = 0.0);
 
 /**
  * <library>omp_npc</library>
@@ -946,7 +946,7 @@ native bool:NPC_StopPlayback(npcid);
 /**
  * <library>omp_npc</library>
  */
-native bool:NPC_PausePlayback(npcid, bool:paused);
+native bool:NPC_PausePlayback(npcid, bool:paused = true);
 
 /**
  * <library>omp_npc</library>
@@ -1072,7 +1072,7 @@ native NPC_GetPathCount();
 /**
  * <library>omp_npc</library>
  */
-native bool:NPC_AddPointToPath(pathid, Float:x, Float:y, Float:z, Float:stopRange);
+native bool:NPC_AddPointToPath(pathid, Float:x, Float:y, Float:z, Float:stopRange = 0.2);
 
 /**
  * <library>omp_npc</library>
@@ -1092,7 +1092,7 @@ native NPC_GetPathPointCount(pathid);
 /**
  * <library>omp_npc</library>
  */
-native bool:NPC_GetPathPoint(pathid, pointIndex, &Float:x, &Float:y, &Float:z, &Float:stopRange);
+native bool:NPC_GetPathPoint(pathid, pointIndex, &Float:x, &Float:y, &Float:z, &Float:stopRange = 0.2);
 
 /**
  * <library>omp_npc</library>

--- a/omp_npc.inc
+++ b/omp_npc.inc
@@ -919,7 +919,7 @@ native NPC_SetSpecialAction(npcid, SPECIAL_ACTION:actionid);
 /**
  * <library>omp_npc</library>
  */
-native NPC_GetSpecialAction(npcid);
+native SPECIAL_ACTION:NPC_GetSpecialAction(npcid);
 
 /*
 native # Playback();

--- a/omp_vehicle.inc
+++ b/omp_vehicle.inc
@@ -579,9 +579,9 @@ native bool:SetVehiclePos(vehicleid, Float:x, Float:y, Float:z);
  * <param name="vehicleid">The ID of the vehicle to get the z angle of</param>
  * <param name="angle">A float variable in which to store the z rotation, passed by reference</param>
  * <seealso name="GetVehicleRotationQuat" />
- * <seealso name="GetVehicleRotation" />
  * <seealso name="SetVehicleZAngle" />
  * <seealso name="GetVehiclePos" />
+ * <seealso name="GetVehicleMatrix" />
  * <seealso name="GetPlayerFacingAngle" />
  * <returns>
  *   <b><c>1</c></b>: The function executed successfully.<br />
@@ -599,20 +599,8 @@ native bool:GetVehicleZAngle(vehicleid, &Float:angle);
  * <param name="y">A float variable in which to store the third quaternion angle, passed by reference</param>
  * <param name="z">A float variable in which to store the fourth quaternion angle, passed by reference</param>
  * <seealso name="GetVehicleZAngle" />
- * <remarks>
- *   <b>To euler:</b><br />
- *   <code>
- *     // GetVehicleRotation Created by IllidanS4<br />
- *     stock GetVehicleRotation(vehicleid, &amp;Float:rx, &amp;Float:ry, &amp;Float:rz)<br />
- *     {<br />
- *         new Float:qw, Float:qx, Float:qy, Float:qz;<br />
- *         GetVehicleRotationQuat(vehicleid, qw, qx, qy, qz);<br />
- *         rx = asin((2 * qy * qz) - (2 * qx * qw));<br />
- *         ry = -atan2((qx * qz) + (qy * qw), 0.5 - (qx * qx) - (qy * qy));<br />
- *         rz = -atan2((qx * qy) + (qz * qw), 0.5 - (qx * qx) - (qz * qz));<br />
- *     }
- *   </code>
- * </remarks>
+ * <seealso name="GetVehicleRotation" />
+ * <seealso name="GetVehicleMatrix" />
  * <remarks>There is no 'set' variation of this function; you can not SET a vehicle's rotation (apart
  * from the <a href="#SetVehicleZAngle">z angle</a>) </remarks>
  * <remarks>This function may return incorrect values for unoccupied vehicles.  The reason is that the
@@ -1606,8 +1594,46 @@ native bool:IsVehicleSirenEnabled(vehicleid);
 
 /**
  * <library>omp_vehicle</library>
+ * <summary>Gets the actual rotation matrix of the vehicle.</summary>
+ * <param name="vehicleid">The ID of the vehicle</param>
+ * <param name="rightX">A float variable in which to store the rightX coordinate, passed by reference</param>
+ * <param name="rightY">A float variable in which to store the rightY coordinate, passed by reference</param>
+ * <param name="rightZ">A float variable in which to store the rightZ coordinate, passed by reference</param>
+ * <param name="upX">A float variable in which to store the upX coordinate, passed by reference</param>
+ * <param name="upY">A float variable in which to store the upY coordinate, passed by reference</param>
+ * <param name="upZ">A float variable in which to store the upZ coordinate, passed by reference</param>
+ * <param name="atX">A float variable in which to store the atX coordinate, passed by reference</param>
+ * <param name="atY">A float variable in which to store the atY coordinate, passed by reference</param>
+ * <param name="atZ">A float variable in which to store the atZ coordinate, passed by reference</param>
+ * <seealso name="GetVehicleRotationQuat" />
+ * <returns>
+ *   <b><c>1</c></b>: The function executed successfully.<br />
+ *   <b><c>0</c></b>: The function failed to execute.  This means the vehicle specified does not exist.
+ * </returns>
  */
 native bool:GetVehicleMatrix(vehicleid, &Float:rightX, &Float:rightY, &Float:rightZ, &Float:upX, &Float:upY, &Float:upZ, &Float:atX, &Float:atY, &Float:atZ);
+
+/**
+ * <library>omp_vehicle</library>
+ * <summary>Returns a vehicle's rotation as euler.</summary>
+ * <param name="vehicleid">The ID of the vehicle to get the rotation of</param>
+ * <param name="x">A float variable in which to store the X axis angle, passed by reference</param>
+ * <param name="y">A float variable in which to store the Y axis angle, passed by reference</param>
+ * <param name="z">A float variable in which to store the Z axis angle, passed by reference</param>
+ * <seealso name="GetVehicleZAngle" />
+ * <seealso name="GetVehicleRotationQuat" />
+ * <seealso name="GetVehicleMatrix" />
+ * <remarks>There is no 'set' variation of this function; you can not SET a vehicle's rotation (apart
+ * from the <a href="#SetVehicleZAngle">z angle</a>) </remarks>
+ * <remarks>This function may return incorrect values for unoccupied vehicles.  The reason is that the
+ * third row of the vehicle's internal rotation matrix gets corrupted if it gets updated while unoccupied.
+ * </remarks>
+ * <returns>
+ *   <b><c>1</c></b>: The function executed successfully.<br />
+ *   <b><c>0</c></b>: The function failed to execute.  This means the vehicle specified does not exist.
+ * </returns>
+ */
+native bool:GetVehicleRotation(vehicleid, &Float:x, &Float:y, &Float:z);
 
 /**
  * <library>omp_vehicle</library>


### PR DESCRIPTION
The main purpose of adding so much optional parameters is in that now you can more easily adapt your FCNPC scripts with much less changes with native's parameters, in case if you actively used optional ones from FCNPC functions (so you've omit them actively, as default values were mostly fit in most of the use cases).

As a minor corrections stuff, it also adds some missed tags (mainly where it was added only for setters before, but getters were forgotten).

UPD: Also declared `GetVehicleRotation` which was missed here, but this function is already present in docs and server implementation.